### PR TITLE
remove further_info_url from source_id

### DIFF
--- a/scripts/cordex_cv/cv.py
+++ b/scripts/cordex_cv/cv.py
@@ -24,6 +24,7 @@ def process_source_id(entry, license):
     entry["license"] = license
     del entry["label_extended"]
     del entry["release_year"]
+    del entry["further_info_url"]
     return entry
 
 


### PR DESCRIPTION
during processing, the `further_info_url` is removed from CV.