### PR TITLE
fix variant_label

### DIFF
--- a/CORDEX-CMIP6_fixed.json
+++ b/CORDEX-CMIP6_fixed.json
@@ -11,7 +11,7 @@
         "tracking_id": [
             "hdl:21.14103/.*"
         ],
-        "variant_label": [
+        "driving_variant_label": [
             "r[[:digit:]]\\{1,\\}i[[:digit:]]\\{1,\\}p[[:digit:]]\\{1,\\}f[[:digit:]]\\{1,\\}$"
         ],
         "Conventions": [


### PR DESCRIPTION
see https://github.com/WCRP-CORDEX/cordex-cmip6-cmor-tables/issues/98

Rename `variant_label` to `driving_variant_label` since this is part of required global attributes.