### PR TITLE
update `source_id`: `REMO2020`

### DIFF
--- a/CORDEX-CMIP6_source_id.json
+++ b/CORDEX-CMIP6_source_id.json
@@ -406,7 +406,7 @@
             "source_id": "RACMO24P",
             "source_type": "ARCM"
         },
-        "REMO2020": {
+        "REMO2020-2-2": {
             "activity_participation": [
                 "DD"
             ],
@@ -417,11 +417,11 @@
             "institution_id": [
                 "GERICS"
             ],
-            "label": "REMO2020",
-            "label_extended": "REMO regional model",
+            "label": "REMO2020-2-2",
+            "label_extended": "Regional Climate Model REMO, version 2.2, hydrostatic configuration with MACv2 aerosol forcing and Fresh-water Lake model (FLake)",
             "license": "Creative Commons Attribution 4.0 International License (CC BY 4.0; https://creativecommons.org/licenses/by/4.0/).",
-            "release_year": "2022",
-            "source_id": "REMO2020",
+            "release_year": "2023",
+            "source_id": "REMO2020-2-2",
             "source_type": "ARCM"
         },
         "ROAM-NBS": {

--- a/docs/CORDEX-CMIP6_source_id.html
+++ b/docs/CORDEX-CMIP6_source_id.html
@@ -277,10 +277,10 @@ a:active { text-decoration: underline; }
             <td>Creative Commons Attribution 4.0 International License (CC BY 4.0; https://creativecommons.org/licenses/by/4.0).</td>
         </tr>
         <tr>
-            <td><a href="https://www.remo-rcm.de">REMO2020</a></td>
-            <td>REMO2020</td>
-            <td>REMO regional model</td>
-            <td>2022</td>
+            <td><a href="https://www.remo-rcm.de">REMO2020-2-2</a></td>
+            <td>REMO2020-2-2</td>
+            <td>Regional Climate Model REMO, version 2.2, hydrostatic configuration with MACv2 aerosol forcing and Fresh-water Lake model (FLake)</td>
+            <td>2023</td>
             <td>ARCM</td>
             <td>GERICS</td>
             <td>DD</td>


### PR DESCRIPTION
@jesusff This REMO2020 source_id needs an update. This was more or less an artificat from the development of these tables. We'll add some more domain_ids for REMO the official way based on #254 

Also letting @Kevstar78 know. This should be the basic hydrostatic configuration on which other source_ids are based, e.g., `REMO2020-2-2-iMOVE`, `REMO2020-2-2-NH`, `REMO2020-2-2-NH-URB`, etc...