### PR TITLE
CV modifications after v2 of archiving specifications for DD

### DIFF
--- a/CORDEX-CMIP6_DRS.json
+++ b/CORDEX-CMIP6_DRS.json
@@ -1,6 +1,6 @@
 {
     "DRS":{
-        "directory_path_template":"<project_id>/<mip_era>/<activity_id>/<domain_id>/<institution_id>/<driving_source_id>/<driving_experiment_id>/<driving_variant_label>/<source_id>/<version_realization>/<frequency>/<variable_id>/<version>",
+        "directory_path_template":"<project_id>/<activity_id>/<domain_id>/<institution_id>/<driving_source_id>/<driving_experiment_id>/<driving_variant_label>/<source_id>/<version_realization>/<frequency>/<variable_id>/<version>",
         "filename_template":"<variable_id>_<domain_id>_<driving_source_id>_<driving_experiment_id>_<driving_variant_label>_<institution_id>_<source_id>_<version_realization>_<frequency>[_<time_range>].nc"
     }
 }

--- a/CORDEX-CMIP6_project_id.json
+++ b/CORDEX-CMIP6_project_id.json
@@ -1,5 +1,5 @@
 {
     "project_id": {
-        "CORDEX": "Coordinated Regional Climate Downscaling Experiment"
+        "CORDEX-CMIP6": "CMIP6-driven Coordinated Regional Climate Downscaling Experiment"
     }
 }


### PR DESCRIPTION
The latest version (v2) of the CORDEX-CMIP6 Archiving Specifications for Dynamical Downscaling (https://doi.org/10.5281/zenodo.15047096) introduces several changes to the CV. Namely:

 * `project_id` changed to from CORDEX to CORDEX-CMIP6
 * `mip_era` dropped from the directory DRS. 