### PR TITLE
update source CV

### DIFF
--- a/scripts/cordex_cv/cv.py
+++ b/scripts/cordex_cv/cv.py
@@ -18,7 +18,10 @@ filelist = [
 
 
 def process_source_id(entry, license):
-    source = [f"{entry['label_extended']} ({entry['release_year']})", entry['label_extended']]
+    source = [
+        f"{entry['label_extended']} ({entry['release_year']})",
+        entry["label_extended"],
+    ]
     entry["source"] = source
     entry["license"] = license
     del entry["label_extended"]


### PR DESCRIPTION
This pull request makes a small change to how the `source` field is constructed in the `process_source_id` function. Instead of a single string, `source` is now a list containing both the formatted label with release year and the label itself. This will allow more flexible usage of the source information in downstream processing.

* Changed the `source` field in `process_source_id` from a string to a list containing both the formatted label and the raw label. (`scripts/cordex_cv/cv.py`)