### PR TITLE
Add regex for version realization

### DIFF
--- a/CORDEX-CMIP6_fixed.json
+++ b/CORDEX-CMIP6_fixed.json
@@ -14,6 +14,9 @@
         "driving_variant_label": [
             "r[[:digit:]]\\{1,\\}i[[:digit:]]\\{1,\\}p[[:digit:]]\\{1,\\}f[[:digit:]]\\{1,\\}$"
         ],
+        "version_realization": [
+            "v[1-9]\\{1,\\}[[:digit:]]\\{0,\\}-r[1-9]\\{1,\\}[[:digit:]]\\{0,\\}$"
+        ],
         "Conventions": [
             "CF-1.11"
         ]


### PR DESCRIPTION
Fixes #233

Tested with the `create-cv` script and works as expected : includes the new regex as a single element list in the CV tables, similar to `driving_variant_label`.

I didn't actually test the new CVs with `cmor`. However, I did test it with `xcmor` after making a few changes (see https://github.com/larsbuntemeyer/xcmor/pull/98) and it worked as expected!