### PR TITLE
Fix ERA5 in esgvoc

### DIFF
--- a/driving_source_id/era5.json
+++ b/driving_source_id/era5.json
@@ -1,5 +1,5 @@
 {
     "@context": "000_context.jsonld",
-    "id": "era-5",
+    "id": "era5",
     "type": "source"
 }


### PR DESCRIPTION
The WCRP-Universe repo has "source" elements referring to ECMWF Reanalysis v5:
- [`era-5.json`](https://github.com/WCRP-CMIP/WCRP-universe/blob/esgvoc/source/era-5.json) : With `activity_participation = "obs4mip"`
- [`era5.json`](https://github.com/WCRP-CMIP/WCRP-universe/blob/esgvoc/source/era5.json) : With `activity_participation = "CORDEX"`

While there is an ambiguity of having two elements referring to the same thing, this repo should probably use the CORDEX one.