### PR TITLE
Add UCSB as driving_institution_id

### DIFF
--- a/CORDEX-CMIP6_driving_institution_id.json
+++ b/CORDEX-CMIP6_driving_institution_id.json
@@ -50,6 +50,7 @@
         "THU": "Department of Earth System Science, Tsinghua University, Beijing 100084, China",
         "UA": "Department of Geosciences, University of Arizona, Tucson, AZ 85721, USA",
         "UCI": "Department of Earth System Science, University of California Irvine, Irvine, CA 92697, USA",
+        "UCSB": "University of California, Santa Barbara, CA 93106, USA",
         "UHH": "Universitat Hamburg, Hamburg 20148, Germany",
         "UTAS": "Institute for Marine and Antarctic Studies, University of Tasmania, Hobart, Tasmania 7001, Australia",
         "UofT": "Department of Physics, University of Toronto, 60 St George Street, Toronto, ON M5S1A7, Canada"


### PR DESCRIPTION
UCSB is a driving institution for E3SM-1-0, but wasn't listed in the `driving_institution_id` list. Here it is.

Also added to the esgvoc_dev branch in #426 .