### PR TITLE
Fix CCAM version

### DIFF
--- a/CORDEX-CMIP6_source_id.json
+++ b/CORDEX-CMIP6_source_id.json
@@ -36,7 +36,7 @@
             "source_id": "BARPA-R1-NN",
             "source_type": "ARCM"
         },
-        "CCAM-2307conv17-SN": {
+        "CCAM-v2307conv17-SN": {
             "activity_participation": [
                 "DD"
             ],
@@ -47,14 +47,14 @@
             "institution_id": [
                 "UNSW-CCRC"
             ],
-            "label": "CCAM-2307conv17-SN",
+            "label": "CCAM-v2307conv17-SN",
             "label_extended": "Conformal Cubic Atmospheric Model version 2307 configuration 2017, with spectral nudging",
             "license": "Creative Commons Attribution 4.0 International License (CC BY 4.0; https://creativecommons.org/licenses/by/4.0).",
             "release_year": "2023",
-            "source_id": "CCAM-2307conv17-SN",
+            "source_id": "CCAM-v2307conv17-SN",
             "source_type": "AGCM"
         },
-        "CCAM-2307conv21-SN": {
+        "CCAM-v2307conv21-SN": {
             "activity_participation": [
                 "DD"
             ],
@@ -65,14 +65,14 @@
             "institution_id": [
                 "UNSW-CCRC"
             ],
-            "label": "CCAM-2307conv21-SN",
+            "label": "CCAM-v2307conv21-SN",
             "label_extended": "Conformal Cubic Atmospheric Model version 2307 configuration 2021, with spectral nudging",
             "license": "Creative Commons Attribution 4.0 International License (CC BY 4.0; https://creativecommons.org/licenses/by/4.0).",
             "release_year": "2023",
-            "source_id": "CCAM-2307conv21-SN",
+            "source_id": "CCAM-v2307conv21-SN",
             "source_type": "AGCM"
         },
-        "CCAM-2507-SN": {
+        "CCAM-v2507-SN": {
             "activity_participation": [
                 "DD"
             ],
@@ -83,11 +83,11 @@
             "institution_id": [
                 "UNSW-CCRC"
             ],
-            "label": "CCAM-2507-SN",
+            "label": "CCAM-v2507-SN",
             "label_extended": "Conformal Cubic Atmospheric Model version 2507 with spectral nudging",
             "license": "Creative Commons Attribution 4.0 International License (CC BY 4.0; https://creativecommons.org/licenses/by/4.0).",
             "release_year": "2025",
-            "source_id": "CCAM-2507-SN",
+            "source_id": "CCAM-v2507-SN",
             "source_type": "AGCM"
         },
         "CCAM-v2105": {

--- a/docs/CORDEX-CMIP6_source_id.html
+++ b/docs/CORDEX-CMIP6_source_id.html
@@ -108,8 +108,8 @@ List of registered models. Visit the <a href="https://github.com/WCRP-CORDEX/cor
             <td>Creative Commons Attribution 4.0 International License (CC BY 4.0; https://creativecommons.org/licenses/by/4.0).</td>
         </tr>
         <tr>
-            <td><a href="https://research.csiro.au/ccam/">CCAM-2307conv17-SN</a></td>
-            <td>CCAM-2307conv17-SN</td>
+            <td><a href="https://research.csiro.au/ccam/">CCAM-v2307conv17-SN</a></td>
+            <td>CCAM-v2307conv17-SN</td>
             <td>Conformal Cubic Atmospheric Model version 2307 configuration 2017, with spectral nudging</td>
             <td>2023</td>
             <td>AGCM</td>
@@ -118,8 +118,8 @@ List of registered models. Visit the <a href="https://github.com/WCRP-CORDEX/cor
             <td>Creative Commons Attribution 4.0 International License (CC BY 4.0; https://creativecommons.org/licenses/by/4.0).</td>
         </tr>
         <tr>
-            <td><a href="https://research.csiro.au/ccam/">CCAM-2307conv21-SN</a></td>
-            <td>CCAM-2307conv21-SN</td>
+            <td><a href="https://research.csiro.au/ccam/">CCAM-v2307conv21-SN</a></td>
+            <td>CCAM-v2307conv21-SN</td>
             <td>Conformal Cubic Atmospheric Model version 2307 configuration 2021, with spectral nudging</td>
             <td>2023</td>
             <td>AGCM</td>
@@ -128,8 +128,8 @@ List of registered models. Visit the <a href="https://github.com/WCRP-CORDEX/cor
             <td>Creative Commons Attribution 4.0 International License (CC BY 4.0; https://creativecommons.org/licenses/by/4.0).</td>
         </tr>
         <tr>
-            <td><a href="https://research.csiro.au/ccam/">CCAM-2507-SN</a></td>
-            <td>CCAM-2507-SN</td>
+            <td><a href="https://research.csiro.au/ccam/">CCAM-v2507-SN</a></td>
+            <td>CCAM-v2507-SN</td>
             <td>Conformal Cubic Atmospheric Model version 2507 with spectral nudging</td>
             <td>2025</td>
             <td>AGCM</td>


### PR DESCRIPTION
to consistently use v before the version number (see #441)