### PR TITLE
Add missing aerosol variable_id entries for CORDEX-CMIP6

### DIFF
--- a/od1000aer.json
+++ b/od1000aer.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "od1000aer",
+    "type": "variable"
+}

--- a/od1000bc.json
+++ b/od1000bc.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "od1000bc",
+    "type": "variable"
+}

--- a/od1000dust.json
+++ b/od1000dust.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "od1000dust",
+    "type": "variable"
+}

--- a/od1000nh4.json
+++ b/od1000nh4.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "od1000nh4",
+    "type": "variable"
+}

--- a/od1000no3.json
+++ b/od1000no3.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "od1000no3",
+    "type": "variable"
+}

--- a/od1000oa.json
+++ b/od1000oa.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "od1000oa",
+    "type": "variable"
+}

--- a/od1000so4.json
+++ b/od1000so4.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "od1000so4",
+    "type": "variable"
+}

--- a/od1000ss.json
+++ b/od1000ss.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "od1000ss",
+    "type": "variable"
+}

--- a/od350aer.json
+++ b/od350aer.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "od350aer",
+    "type": "variable"
+}

--- a/od350bc.json
+++ b/od350bc.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "od350bc",
+    "type": "variable"
+}

--- a/od350dust.json
+++ b/od350dust.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "od350dust",
+    "type": "variable"
+}

--- a/od350nh4.json
+++ b/od350nh4.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "od350nh4",
+    "type": "variable"
+}

--- a/od350no3.json
+++ b/od350no3.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "od350no3",
+    "type": "variable"
+}

--- a/od350oa.json
+++ b/od350oa.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "od350oa",
+    "type": "variable"
+}

--- a/od350so4.json
+++ b/od350so4.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "od350so4",
+    "type": "variable"
+}

--- a/od350ss.json
+++ b/od350ss.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "od350ss",
+    "type": "variable"
+}

--- a/od440bc.json
+++ b/od440bc.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "od440bc",
+    "type": "variable"
+}

--- a/od440dust.json
+++ b/od440dust.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "od440dust",
+    "type": "variable"
+}

--- a/od440nh4.json
+++ b/od440nh4.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "od440nh4",
+    "type": "variable"
+}

--- a/od440no3.json
+++ b/od440no3.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "od440no3",
+    "type": "variable"
+}

--- a/od440oa.json
+++ b/od440oa.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "od440oa",
+    "type": "variable"
+}

--- a/od440so4.json
+++ b/od440so4.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "od440so4",
+    "type": "variable"
+}

--- a/od440ss.json
+++ b/od440ss.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "od440ss",
+    "type": "variable"
+}

--- a/od550bc.json
+++ b/od550bc.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "od550bc",
+    "type": "variable"
+}

--- a/od550dust.json
+++ b/od550dust.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "od550dust",
+    "type": "variable"
+}

--- a/od550lt1aer.json
+++ b/od550lt1aer.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "od550lt1aer",
+    "type": "variable"
+}

--- a/od550nh4.json
+++ b/od550nh4.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "od550nh4",
+    "type": "variable"
+}

--- a/od550no3.json
+++ b/od550no3.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "od550no3",
+    "type": "variable"
+}

--- a/od550oa.json
+++ b/od550oa.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "od550oa",
+    "type": "variable"
+}

--- a/od550so4.json
+++ b/od550so4.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "od550so4",
+    "type": "variable"
+}

--- a/od550soa.json
+++ b/od550soa.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "od550soa",
+    "type": "variable"
+}

--- a/od550ss.json
+++ b/od550ss.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "od550ss",
+    "type": "variable"
+}

--- a/od870aer.json
+++ b/od870aer.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "od870aer",
+    "type": "variable"
+}

--- a/od870bc.json
+++ b/od870bc.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "od870bc",
+    "type": "variable"
+}

--- a/od870dust.json
+++ b/od870dust.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "od870dust",
+    "type": "variable"
+}

--- a/od870nh4.json
+++ b/od870nh4.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "od870nh4",
+    "type": "variable"
+}

--- a/od870no3.json
+++ b/od870no3.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "od870no3",
+    "type": "variable"
+}

--- a/od870oa.json
+++ b/od870oa.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "od870oa",
+    "type": "variable"
+}

--- a/od870so4.json
+++ b/od870so4.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "od870so4",
+    "type": "variable"
+}

--- a/od870ss.json
+++ b/od870ss.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "od870ss",
+    "type": "variable"
+}

--- a/rldsaf.json
+++ b/rldsaf.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "rldsaf",
+    "type": "variable"
+}

--- a/rldscsaf.json
+++ b/rldscsaf.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "rldscsaf",
+    "type": "variable"
+}

--- a/rlusaf.json
+++ b/rlusaf.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "rlusaf",
+    "type": "variable"
+}

--- a/rluscsaf.json
+++ b/rluscsaf.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "rluscsaf",
+    "type": "variable"
+}

--- a/rlutaf.json
+++ b/rlutaf.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "rlutaf",
+    "type": "variable"
+}

--- a/rlutcsaf.json
+++ b/rlutcsaf.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "rlutcsaf",
+    "type": "variable"
+}

--- a/rsdsaf.json
+++ b/rsdsaf.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "rsdsaf",
+    "type": "variable"
+}

--- a/rsdscsaf.json
+++ b/rsdscsaf.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "rsdscsaf",
+    "type": "variable"
+}

--- a/rsusaf.json
+++ b/rsusaf.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "rsusaf",
+    "type": "variable"
+}

--- a/rsuscsaf.json
+++ b/rsuscsaf.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "rsuscsaf",
+    "type": "variable"
+}

--- a/rsutaf.json
+++ b/rsutaf.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "rsutaf",
+    "type": "variable"
+}

--- a/rsutcsaf.json
+++ b/rsutcsaf.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "rsutcsaf",
+    "type": "variable"
+}

--- a/scat550aer.json
+++ b/scat550aer.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "scat550aer",
+    "type": "variable"
+}

--- a/scat550bc.json
+++ b/scat550bc.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "scat550bc",
+    "type": "variable"
+}

--- a/scat550dust.json
+++ b/scat550dust.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "scat550dust",
+    "type": "variable"
+}

--- a/scat550nh4.json
+++ b/scat550nh4.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "scat550nh4",
+    "type": "variable"
+}

--- a/scat550no3.json
+++ b/scat550no3.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "scat550no3",
+    "type": "variable"
+}

--- a/scat550oa.json
+++ b/scat550oa.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "scat550oa",
+    "type": "variable"
+}

--- a/scat550so4.json
+++ b/scat550so4.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "scat550so4",
+    "type": "variable"
+}

--- a/scat550ss.json
+++ b/scat550ss.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "scat550ss",
+    "type": "variable"
+}

--- a/sconcbc.json
+++ b/sconcbc.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "sconcbc",
+    "type": "variable"
+}

--- a/sconcdust.json
+++ b/sconcdust.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "sconcdust",
+    "type": "variable"
+}

--- a/sconcnh4.json
+++ b/sconcnh4.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "sconcnh4",
+    "type": "variable"
+}

--- a/sconcno3.json
+++ b/sconcno3.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "sconcno3",
+    "type": "variable"
+}

--- a/sconcoa.json
+++ b/sconcoa.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "sconcoa",
+    "type": "variable"
+}

--- a/sconcso4.json
+++ b/sconcso4.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "sconcso4",
+    "type": "variable"
+}

--- a/sconcsoa.json
+++ b/sconcsoa.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "sconcsoa",
+    "type": "variable"
+}

--- a/sconcss.json
+++ b/sconcss.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "sconcss",
+    "type": "variable"
+}

--- a/sedbc.json
+++ b/sedbc.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "sedbc",
+    "type": "variable"
+}

--- a/seddust.json
+++ b/seddust.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "seddust",
+    "type": "variable"
+}

--- a/sednh4.json
+++ b/sednh4.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "sednh4",
+    "type": "variable"
+}

--- a/sedno3.json
+++ b/sedno3.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "sedno3",
+    "type": "variable"
+}

--- a/sedoa.json
+++ b/sedoa.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "sedoa",
+    "type": "variable"
+}

--- a/sedso4.json
+++ b/sedso4.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "sedso4",
+    "type": "variable"
+}

--- a/sedss.json
+++ b/sedss.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "sedss",
+    "type": "variable"
+}

--- a/ssa1000aer.json
+++ b/ssa1000aer.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "ssa1000aer",
+    "type": "variable"
+}

--- a/ssa350aer.json
+++ b/ssa350aer.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "ssa350aer",
+    "type": "variable"
+}

--- a/ssa440aer.json
+++ b/ssa440aer.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "ssa440aer",
+    "type": "variable"
+}

--- a/ssa550aer.json
+++ b/ssa550aer.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "ssa550aer",
+    "type": "variable"
+}

--- a/ssa870aer.json
+++ b/ssa870aer.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "ssa870aer",
+    "type": "variable"
+}

--- a/toz.json
+++ b/toz.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "toz",
+    "type": "variable"
+}

--- a/variable_id/abs1000aer.json
+++ b/variable_id/abs1000aer.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "abs1000aer",
+    "type": "variable"
+}

--- a/variable_id/abs1000bc.json
+++ b/variable_id/abs1000bc.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "abs1000bc",
+    "type": "variable"
+}

--- a/variable_id/abs1000dust.json
+++ b/variable_id/abs1000dust.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "abs1000dust",
+    "type": "variable"
+}

--- a/variable_id/abs1000nh4.json
+++ b/variable_id/abs1000nh4.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "abs1000nh4",
+    "type": "variable"
+}

--- a/variable_id/abs1000no3.json
+++ b/variable_id/abs1000no3.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "abs1000no3",
+    "type": "variable"
+}

--- a/variable_id/abs1000oa.json
+++ b/variable_id/abs1000oa.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "abs1000oa",
+    "type": "variable"
+}

--- a/variable_id/abs1000so4.json
+++ b/variable_id/abs1000so4.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "abs1000so4",
+    "type": "variable"
+}

--- a/variable_id/abs1000ss.json
+++ b/variable_id/abs1000ss.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "abs1000ss",
+    "type": "variable"
+}

--- a/variable_id/abs350aer.json
+++ b/variable_id/abs350aer.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "abs350aer",
+    "type": "variable"
+}

--- a/variable_id/abs350bc.json
+++ b/variable_id/abs350bc.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "abs350bc",
+    "type": "variable"
+}

--- a/variable_id/abs350dust.json
+++ b/variable_id/abs350dust.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "abs350dust",
+    "type": "variable"
+}

--- a/variable_id/abs350nh4.json
+++ b/variable_id/abs350nh4.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "abs350nh4",
+    "type": "variable"
+}

--- a/variable_id/abs350no3.json
+++ b/variable_id/abs350no3.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "abs350no3",
+    "type": "variable"
+}

--- a/variable_id/abs350oa.json
+++ b/variable_id/abs350oa.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "abs350oa",
+    "type": "variable"
+}

--- a/variable_id/abs350so4.json
+++ b/variable_id/abs350so4.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "abs350so4",
+    "type": "variable"
+}

--- a/variable_id/abs350ss.json
+++ b/variable_id/abs350ss.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "abs350ss",
+    "type": "variable"
+}

--- a/variable_id/abs440aer.json
+++ b/variable_id/abs440aer.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "abs440aer",
+    "type": "variable"
+}

--- a/variable_id/abs440bc.json
+++ b/variable_id/abs440bc.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "abs440bc",
+    "type": "variable"
+}

--- a/variable_id/abs440dust.json
+++ b/variable_id/abs440dust.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "abs440dust",
+    "type": "variable"
+}

--- a/variable_id/abs440nh4.json
+++ b/variable_id/abs440nh4.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "abs440nh4",
+    "type": "variable"
+}

--- a/variable_id/abs440no3.json
+++ b/variable_id/abs440no3.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "abs440no3",
+    "type": "variable"
+}

--- a/variable_id/abs440oa.json
+++ b/variable_id/abs440oa.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "abs440oa",
+    "type": "variable"
+}

--- a/variable_id/abs440so4.json
+++ b/variable_id/abs440so4.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "abs440so4",
+    "type": "variable"
+}

--- a/variable_id/abs440ss.json
+++ b/variable_id/abs440ss.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "abs440ss",
+    "type": "variable"
+}

--- a/variable_id/abs550aer.json
+++ b/variable_id/abs550aer.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "abs550aer",
+    "type": "variable"
+}

--- a/variable_id/abs550bc.json
+++ b/variable_id/abs550bc.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "abs550bc",
+    "type": "variable"
+}

--- a/variable_id/abs550dust.json
+++ b/variable_id/abs550dust.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "abs550dust",
+    "type": "variable"
+}

--- a/variable_id/abs550nh4.json
+++ b/variable_id/abs550nh4.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "abs550nh4",
+    "type": "variable"
+}

--- a/variable_id/abs550no3.json
+++ b/variable_id/abs550no3.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "abs550no3",
+    "type": "variable"
+}

--- a/variable_id/abs550oa.json
+++ b/variable_id/abs550oa.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "abs550oa",
+    "type": "variable"
+}

--- a/variable_id/abs550so4.json
+++ b/variable_id/abs550so4.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "abs550so4",
+    "type": "variable"
+}

--- a/variable_id/abs550ss.json
+++ b/variable_id/abs550ss.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "abs550ss",
+    "type": "variable"
+}

--- a/variable_id/abs870aer.json
+++ b/variable_id/abs870aer.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "abs870aer",
+    "type": "variable"
+}

--- a/variable_id/abs870bc.json
+++ b/variable_id/abs870bc.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "abs870bc",
+    "type": "variable"
+}

--- a/variable_id/abs870dust.json
+++ b/variable_id/abs870dust.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "abs870dust",
+    "type": "variable"
+}

--- a/variable_id/abs870nh4.json
+++ b/variable_id/abs870nh4.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "abs870nh4",
+    "type": "variable"
+}

--- a/variable_id/abs870no3.json
+++ b/variable_id/abs870no3.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "abs870no3",
+    "type": "variable"
+}

--- a/variable_id/abs870oa.json
+++ b/variable_id/abs870oa.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "abs870oa",
+    "type": "variable"
+}

--- a/variable_id/abs870so4.json
+++ b/variable_id/abs870so4.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "abs870so4",
+    "type": "variable"
+}

--- a/variable_id/abs870ss.json
+++ b/variable_id/abs870ss.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "abs870ss",
+    "type": "variable"
+}

--- a/variable_id/asy1000aer.json
+++ b/variable_id/asy1000aer.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "asy1000aer",
+    "type": "variable"
+}

--- a/variable_id/asy350aer.json
+++ b/variable_id/asy350aer.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "asy350aer",
+    "type": "variable"
+}

--- a/variable_id/asy440aer.json
+++ b/variable_id/asy440aer.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "asy440aer",
+    "type": "variable"
+}

--- a/variable_id/asy550aer.json
+++ b/variable_id/asy550aer.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "asy550aer",
+    "type": "variable"
+}

--- a/variable_id/asy870aer.json
+++ b/variable_id/asy870aer.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "asy870aer",
+    "type": "variable"
+}

--- a/variable_id/cdnc.json
+++ b/variable_id/cdnc.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "cdnc",
+    "type": "variable"
+}

--- a/variable_id/cheaqpso4.json
+++ b/variable_id/cheaqpso4.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "cheaqpso4",
+    "type": "variable"
+}

--- a/variable_id/chegpso4.json
+++ b/variable_id/chegpso4.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "chegpso4",
+    "type": "variable"
+}

--- a/variable_id/chepnh4.json
+++ b/variable_id/chepnh4.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "chepnh4",
+    "type": "variable"
+}

--- a/variable_id/chepno3.json
+++ b/variable_id/chepno3.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "chepno3",
+    "type": "variable"
+}

--- a/variable_id/chepsoa.json
+++ b/variable_id/chepsoa.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "chepsoa",
+    "type": "variable"
+}

--- a/variable_id/concbc.json
+++ b/variable_id/concbc.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "concbc",
+    "type": "variable"
+}

--- a/variable_id/concdust.json
+++ b/variable_id/concdust.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "concdust",
+    "type": "variable"
+}

--- a/variable_id/concnh4.json
+++ b/variable_id/concnh4.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "concnh4",
+    "type": "variable"
+}

--- a/variable_id/concno3.json
+++ b/variable_id/concno3.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "concno3",
+    "type": "variable"
+}

--- a/variable_id/concoa.json
+++ b/variable_id/concoa.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "concoa",
+    "type": "variable"
+}

--- a/variable_id/concso4.json
+++ b/variable_id/concso4.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "concso4",
+    "type": "variable"
+}

--- a/variable_id/concss.json
+++ b/variable_id/concss.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "concss",
+    "type": "variable"
+}

--- a/variable_id/drybc.json
+++ b/variable_id/drybc.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "drybc",
+    "type": "variable"
+}

--- a/variable_id/drydust.json
+++ b/variable_id/drydust.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "drydust",
+    "type": "variable"
+}

--- a/variable_id/drynh4.json
+++ b/variable_id/drynh4.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "drynh4",
+    "type": "variable"
+}

--- a/variable_id/dryno3.json
+++ b/variable_id/dryno3.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "dryno3",
+    "type": "variable"
+}

--- a/variable_id/dryoa.json
+++ b/variable_id/dryoa.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "dryoa",
+    "type": "variable"
+}

--- a/variable_id/dryso4.json
+++ b/variable_id/dryso4.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "dryso4",
+    "type": "variable"
+}

--- a/variable_id/dryss.json
+++ b/variable_id/dryss.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "dryss",
+    "type": "variable"
+}

--- a/variable_id/emibc.json
+++ b/variable_id/emibc.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "emibc",
+    "type": "variable"
+}

--- a/variable_id/emidust.json
+++ b/variable_id/emidust.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "emidust",
+    "type": "variable"
+}

--- a/variable_id/eminh3.json
+++ b/variable_id/eminh3.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "eminh3",
+    "type": "variable"
+}

--- a/variable_id/eminox.json
+++ b/variable_id/eminox.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "eminox",
+    "type": "variable"
+}

--- a/variable_id/emioa.json
+++ b/variable_id/emioa.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "emioa",
+    "type": "variable"
+}

--- a/variable_id/emiso2.json
+++ b/variable_id/emiso2.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "emiso2",
+    "type": "variable"
+}

--- a/variable_id/emiso4.json
+++ b/variable_id/emiso4.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "emiso4",
+    "type": "variable"
+}

--- a/variable_id/emiss.json
+++ b/variable_id/emiss.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "emiss",
+    "type": "variable"
+}

--- a/variable_id/emivoc.json
+++ b/variable_id/emivoc.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "emivoc",
+    "type": "variable"
+}

--- a/variable_id/ext550aer.json
+++ b/variable_id/ext550aer.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "ext550aer",
+    "type": "variable"
+}

--- a/variable_id/ext550bc.json
+++ b/variable_id/ext550bc.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "ext550bc",
+    "type": "variable"
+}

--- a/variable_id/ext550dust.json
+++ b/variable_id/ext550dust.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "ext550dust",
+    "type": "variable"
+}

--- a/variable_id/ext550nh4.json
+++ b/variable_id/ext550nh4.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "ext550nh4",
+    "type": "variable"
+}

--- a/variable_id/ext550no3.json
+++ b/variable_id/ext550no3.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "ext550no3",
+    "type": "variable"
+}

--- a/variable_id/ext550oa.json
+++ b/variable_id/ext550oa.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "ext550oa",
+    "type": "variable"
+}

--- a/variable_id/ext550so4.json
+++ b/variable_id/ext550so4.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "ext550so4",
+    "type": "variable"
+}

--- a/variable_id/ext550ss.json
+++ b/variable_id/ext550ss.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "ext550ss",
+    "type": "variable"
+}

--- a/wetbc.json
+++ b/wetbc.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "wetbc",
+    "type": "variable"
+}

--- a/wetdust.json
+++ b/wetdust.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "wetdust",
+    "type": "variable"
+}

--- a/wetnh4.json
+++ b/wetnh4.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "wetnh4",
+    "type": "variable"
+}

--- a/wetno3.json
+++ b/wetno3.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "wetno3",
+    "type": "variable"
+}

--- a/wetoa.json
+++ b/wetoa.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "wetoa",
+    "type": "variable"
+}

--- a/wetso4.json
+++ b/wetso4.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "wetso4",
+    "type": "variable"
+}

--- a/wetss.json
+++ b/wetss.json
@@ -1,0 +1,5 @@
+{
+    "@context": "000_context.jsonld",
+    "id": "wetss",
+    "type": "variable"
+}


### PR DESCRIPTION
This PR adds missing aerosol-related variable_id entries for CORDEX-CMIP6.

The variables were checked against Universe and added to CORDEX-CMIP6 where missing.

Closes #461